### PR TITLE
fix: Replace certbot-auto with certbot in install-letsencrypt-cert.sh

### DIFF
--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -25,9 +25,28 @@ read EMAIL
 
 cd /usr/local/sbin
 
-if [ ! -f certbot-auto ] ; then
-  wget https://dl.eff.org/certbot-auto
-  chmod a+x ./certbot-auto
+if [ ! -x "$(command -v certbot)" ] ; then
+    DISTRO=$(lsb_release -is)
+    DISTRO_VERSION=$(lsb_release -rs)
+    if [ "$DISTRO" = "Debian" ]; then
+        apt-get update
+        apt-get -y install certbot
+    elif [ "$DISTRO" = "Ubuntu" ]; then
+        if [ "$DISTRO_VERSION" = "20.04" ] || [ "$DISTRO_VERSION" = "19.10" ]; then
+                apt-get update
+                apt-get -y install software-properties-common
+                add-apt-repository -y universe
+                apt-get update
+                apt-get -y install certbot
+        elif [ "$DISTRO_VERSION" = "18.04" ]; then
+                apt-get update
+                apt-get -y install software-properties-common
+                add-apt-repository -y universe
+                add-apt-repository -y ppa:certbot/certbot
+                apt-get update
+                apt-get -y install certbot
+        fi
+    fi
 fi
 
 CRON_FILE="/etc/cron.weekly/letsencrypt-renew"
@@ -35,7 +54,7 @@ if [ ! -d "/etc/cron.weekly" ] ; then
     mkdir "/etc/cron.weekly"
 fi
 echo "#!/bin/bash" > $CRON_FILE
-echo "/usr/local/sbin/certbot-auto renew >> /var/log/le-renew.log" >> $CRON_FILE
+echo "/usr/bin/certbot renew >> /var/log/le-renew.log" >> $CRON_FILE
 
 CERT_KEY="/etc/letsencrypt/live/$DOMAIN/privkey.pem"
 CERT_CRT="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
@@ -51,13 +70,13 @@ if [ -f /etc/nginx/sites-enabled/$DOMAIN.conf ] ; then
         chmod u+x $TURN_HOOK
         sed -i "s/jitsi-meet.example.com/$DOMAIN/g" $TURN_HOOK
 
-        ./certbot-auto certonly --noninteractive \
+        /usr/bin/certbot certonly --noninteractive \
         --webroot --webroot-path /usr/share/jitsi-meet \
         -d $DOMAIN \
         --agree-tos --email $EMAIL \
         --deploy-hook $TURN_HOOK
     else
-        ./certbot-auto certonly --noninteractive \
+        /usr/bin/certbot certonly --noninteractive \
         --webroot --webroot-path /usr/share/jitsi-meet \
         -d $DOMAIN \
         --agree-tos --email $EMAIL
@@ -79,7 +98,7 @@ if [ -f /etc/nginx/sites-enabled/$DOMAIN.conf ] ; then
     service nginx reload
 elif [ -f /etc/apache2/sites-enabled/$DOMAIN.conf ] ; then
 
-    ./certbot-auto certonly --noninteractive \
+    /usr/bin/certbot certonly --noninteractive \
     --webroot --webroot-path /usr/share/jitsi-meet \
     -d $DOMAIN \
     --agree-tos --email $EMAIL


### PR DESCRIPTION
I added in some logic to install certbot for ubuntu 18.04, 19.10, 20.04 and Debian 9,10. This will not work for Debian 8 but this version goes EOL in 4 weeks and uses certbot-auto.

I tested this as working on all four target distros.